### PR TITLE
Security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the library will be documented in this file.
 The format of the file is based on [Keep a Changelog](http://keepachangelog.com/)
 and this library adheres to [Semantic Versioning](http://semver.org/) as mentioned in [README.md][readme] file.
 
+## [Unreleased]
+
+⚠ IMPORTANT NOTE: From this point onward Python 3.7 is no longer supported. The minimum supported version is Python 3.8 due to dependency updates.
+
+### Security
+* Bumped werkzeug dependency from 2.1.2 to 3.0.3
+* Bumped pytest-httpserver dependency from 1.0.4 to 1.0.8
+
 ## [ [4.0.0](https://github.com/infobip/infobip-api-python-client/releases/tag/4.0.0) ] - 2024-06-13
 🎉 **NEW Major Version of `infobip_api_client`.**
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pytest==6.2.5
-pytest-httpserver==1.0.4
+pytest-httpserver==1.0.8
 pytest-cases==3.6.8
 pytest-cov==3.0.0
 wheel==0.38.0
-werkzeug==2.1.2
+werkzeug==3.0.3


### PR DESCRIPTION
Bumped dependency versions. Python version that is supported is changed to >=3.8.